### PR TITLE
Http cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'bootstrap-sass'
 gem 'font-awesome-sass'
 gem 'octokit'
 gem 'simple_form'
-gem 'redis'
+gem 'faraday-http-cache'
 gem 'rack-mini-profiler'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.0)
+      faraday (~> 0.8)
     font-awesome-sass (4.5.0)
       sass (>= 3.2)
     globalid (0.3.6)
@@ -121,7 +123,6 @@ GEM
     rake (11.1.1)
     rdoc (4.2.2)
       json (~> 1.4)
-    redis (3.2.2)
     sass (3.4.21)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -170,6 +171,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
   dotenv-rails
+  faraday-http-cache
   font-awesome-sass
   jbuilder (~> 2.0)
   jquery-rails
@@ -177,7 +179,6 @@ DEPENDENCIES
   puma
   rack-mini-profiler
   rails (= 4.2.5.1)
-  redis
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   simple_form

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,0 +1,7 @@
+stack = Faraday::RackBuilder.new do |builder|
+  builder.use Faraday::HttpCache, shared_cache: false
+  builder.use Octokit::Response::RaiseError
+  builder.adapter Faraday.default_adapter
+  builder.response :logger
+end
+Octokit.middleware = stack

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,4 +1,5 @@
 stack = Faraday::RackBuilder.new do |builder|
+  # shared_cache: false will cache private responses
   builder.use Faraday::HttpCache, shared_cache: false
   builder.use Octokit::Response::RaiseError
   builder.adapter Faraday.default_adapter


### PR DESCRIPTION
Fixes #15

This uses the faraday middleware to cache octokit http responses

no need for redis
